### PR TITLE
remove shadowing

### DIFF
--- a/gym/data/download_d4rl_datasets.py
+++ b/gym/data/download_d4rl_datasets.py
@@ -9,9 +9,9 @@ import d4rl
 
 datasets = []
 
-for env in ['halfcheetah', 'hopper', 'walker2d']:
+for env_name in ['halfcheetah', 'hopper', 'walker2d']:
 	for dataset_type in ['medium', 'medium-replay', 'expert']:
-		name = f'{env}-{dataset_type}-v2'
+		name = f'{env_name}-{dataset_type}-v2'
 		env = gym.make(name)
 		dataset = env.get_dataset()
 


### PR DESCRIPTION
`env` is redefined inside the dataset_type loop. This will raise an error for the next iteration.