### PR TITLE
Clarified that return_preds were unnecessary

### DIFF
--- a/gym/decision_transformer/models/decision_transformer.py
+++ b/gym/decision_transformer/models/decision_transformer.py
@@ -134,7 +134,7 @@ class DecisionTransformer(TrajectoryModel):
         else:
             attention_mask = None
 
-        _, action_preds, return_preds = self.forward(
+        _, action_preds, _ = self.forward(
             states, actions, None, returns_to_go, timesteps, attention_mask=attention_mask, **kwargs)
 
         return action_preds[0,-1]


### PR DESCRIPTION
I liked your code! It's so easy to re-implement that. and I found that there looks no need to get return_preds in forward method, so I replaced the return_preds with _ variable to let people use this code more confidently