### PR TITLE
fix the slicing of action predictions

### DIFF
--- a/atari/mingpt/model_atari.py
+++ b/atari/mingpt/model_atari.py
@@ -265,7 +265,7 @@ class GPT(nn.Module):
         if actions is not None and self.model_type == 'reward_conditioned':
             logits = logits[:, 1::3, :] # only keep predictions from state_embeddings
         elif actions is None and self.model_type == 'reward_conditioned':
-            logits = logits[:, 1:, :]
+            logits = logits[:, 1::2, :]
         elif actions is not None and self.model_type == 'naive':
             logits = logits[:, ::2, :] # only keep predictions from state_embeddings
         elif actions is None and self.model_type == 'naive':


### PR DESCRIPTION
I think [slice of action prediction here](https://github.com/kzl/decision-transformer/blob/e2d82e68f330c00f763507b3b01d774740bee53f/atari/mingpt/model_atari.py#L268) should be 
```python
            logits = logits[:, 1::2, :]
```
Am I right?